### PR TITLE
Fix compiler error when compiling with clang-cl

### DIFF
--- a/source/EATest.cpp
+++ b/source/EATest.cpp
@@ -37,7 +37,7 @@
     extern "C" WINBASEAPI BOOL WINAPI IsDebuggerPresent();
 
     #if EA_WINAPI_FAMILY_PARTITION(EA_WINAPI_PARTITION_DESKTOP) && !defined(EA_COMPILER_CLANG)
-        #pragma comment(lib, "Advapi32.lib"); // For CheckTokenMembership and friends.
+        #pragma comment(lib, "Advapi32.lib") // For CheckTokenMembership and friends.
     #endif
 
 #elif defined(__APPLE__)    // OS X, iPhone, iPad, etc.


### PR DESCRIPTION
Fixes the error `pragma comment requires parenthesized identifier and optional string` when compiling with clang-cl.