### PR TITLE
Fix CMake build on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 # Include directories
 #-------------------------------------------------------------------------------------------
 target_include_directories(EATest PUBLIC include)
+target_include_directories(EATest PRIVATE ../EABase/include/Common)
 
 #-------------------------------------------------------------------------------------------
 # Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(EATest PRIVATE ../EABase/include/Common)
 #-------------------------------------------------------------------------------------------
 # Dependencies
 #-------------------------------------------------------------------------------------------
-target_link_libraries(EATest EABase)
 target_link_libraries(EATest EAStdC)
 target_link_libraries(EATest EASTL)
 target_link_libraries(EATest EAMain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,7 @@ add_subdirectory(packages/EAStdC)
 add_subdirectory(packages/EAThread)
 
 target_link_libraries(EATestTest EAAssert)
-target_link_libraries(EATestTest EABase)
+)
 target_link_libraries(EATestTest EAMain)
 target_link_libraries(EATestTest EASTL)
 target_link_libraries(EATestTest EAStdC)


### PR DESCRIPTION
Change EABase from link to include - the libraries won't build otherwise on Ubuntu.
I'm guessing that in the past EABase was a binary library to link against, and was changed to header only - but I didn't chase its history.